### PR TITLE
DEV: Fix "make html" Docs build failure in Gitpod

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - pandas
   - matplotlib
   - pydata-sphinx-theme=0.7.2
-  - breathe
+  - breathe=4.31.0 #pinned until version > 4.33.0 is default for conda
   # For linting
   - pycodestyle=2.7.0
   - gitpython


### PR DESCRIPTION
This PR is opened in response to discussion in issue #21252 and hopefully closing this issue.

A lot of other builds(including numpy's) were failing for the newly released version of Breathe 4.33.0. They quickly released a path `4.33.1`. but currently it is not uploaded on conda. 

Until then, A change is proposed to pin the breathe version to Tested/Working version of `4.31.0`